### PR TITLE
Fix so that the private/public check is consistent when editing a stream

### DIFF
--- a/app/views/streams/_form_step1.html.erb
+++ b/app/views/streams/_form_step1.html.erb
@@ -22,7 +22,7 @@
 
   <div class="form-group">
     <%= f.label :private %><br>
-    <%= f.check_box :private, class: "form-control switch-private clearfix", checked: true  %>
+    <%= f.check_box :private, class: "form-control switch-private clearfix", checked: (@stream.private == true) %>
   </div>
 
   <div class="form-group">


### PR DESCRIPTION
Now the private/public check box is set to public as default when creating a stream and will later be set to what ever the stream is set to be.
