### PR TITLE
Polling toggle set to be consistent with a stream's info

### DIFF
--- a/app/assets/javascripts/streams.new.js.coffee
+++ b/app/assets/javascripts/streams.new.js.coffee
@@ -175,7 +175,8 @@ window.newStreamForm = (form) ->
     sw = form.find('.switch-polling').wrap(html).parent().bootstrapSwitch()
     sw.bootstrapSwitch 'setOnLabel', 'Push'
     sw.bootstrapSwitch 'setOffLabel', 'Poll'
-    sw.bootstrapSwitch 'setState', true
+    if sw.bootstrapSwitch('status') is false
+      do showPollingPanel
     sw.on 'switch-change', switchChanged
 
 

--- a/app/views/streams/_form_step3.html.erb
+++ b/app/views/streams/_form_step3.html.erb
@@ -1,7 +1,7 @@
 <div class="step" id="step-3">
   <div class="form-group">
     <label>Mechanism for updating data values</label><br>
-    <%= f.check_box :polling, class: "form-control switch-polling clearfix" %>
+    <%= f.check_box :polling, class: "form-control switch-polling clearfix", checked: !@stream.polling %>
   </div>
 
   <div class="polling" style="display: none;">


### PR DESCRIPTION
Now a stream shows it's polling info if it has been set before, when editing
